### PR TITLE
Use UPSERT_PENDING dedupe strategy (default is UNIQUE)

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range for Chrome",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Capture work from your browser based tools and share progress with your team.",
   "permissions": ["storage", "cookies", "https://api.range.co/*"],
   "browser_action": {

--- a/ext/sites/_base.js
+++ b/ext/sites/_base.js
@@ -327,6 +327,7 @@ class Monitor {
     return {
       reason: resolve(this._reason),
       snippet_type: resolve(this._snippetType),
+      dedupe_strategy: 'UPSERT_PENDING',
       attachment: {
         source_id: sourceID,
         provider: resolve(this._provider),


### PR DESCRIPTION
#### What's this PR do?

Changes the dedupe strategy used by the extension to UPSERT_PENDING.

#### Where should the reviewer start?

Short diff.

#### Any background context you want to provide?

The default is UNIQUE which means that each artifact will only ever be suggested
once. This change means that continuing to work on the same document for
multiple days will allow multiple suggestions to be made.

#### What are the relevant tickets?

N/A

#### Screenshots (if appropriate)

N/A

#### What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/W0fgdNlZAbdfy/200w_d.gif)

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered