### PR TITLE
Read Dropbox Paper data from the DOM instead of OG data

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range for Chrome",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Capture work from your browser based tools and share progress with your team.",
   "permissions": ["storage", "cookies", "https://api.range.co/*"],
   "browser_action": {

--- a/ext/sites/confluence.js
+++ b/ext/sites/confluence.js
@@ -5,7 +5,7 @@ const wikiURL = /^\/wiki\/spaces\/([A-Z]+)\/pages\/edit(?:-v2)?\/([0-9]+)$/;
 new Monitor()
   .pathMatch(wikiURL)
   .resetOnNav()
-  .requireKeypress(10)
+  .requireKeypress(5)
 
   .reason(Reasons.EDITED)
   .past()

--- a/ext/sites/dropbox.js
+++ b/ext/sites/dropbox.js
@@ -4,7 +4,7 @@
 new Monitor()
   .pathMatch(/^\/doc\//)
   .resetOnNav()
-  .requireKeypress(10)
+  .requireKeypress(5)
 
   .reason(Reasons.EDITED)
   .past()
@@ -14,16 +14,16 @@ new Monitor()
   // or sometimes:
   //   https://paper.dropbox.com/doc/[base64id]
   .sourceID(() => {
-    let url = openGraph('og:url');
-    let i = url.indexOf('--');
-    if (i !== -1) return url.substr(i + 2);
-    else return url.split('/').pop();
+    let p = document.location.pathname;
+    let i = p.indexOf('--');
+    if (i !== -1) return p.substr(i + 2);
+    else return p.split('/').pop();
   })
 
   .setProvider('dropbox_paper', 'Dropbox Paper')
   .setType(Types.DOCUMENT)
   .attachment({
-    name: () => openGraph('og:title'),
-    html_url: () => openGraph('og:url'),
-    description: () => openGraph('og:description'),
+    name: () => textContent('.hp-header-title', 'Untitled'),
+    html_url: () => document.location.href,
+    description: () => '',
   });


### PR DESCRIPTION
#### What's this PR do?

Updates the Dropbox Paper adaptor to read information from the DOM.

#### Where should the reviewer start?

Diff

#### Any background context you want to provide?

We were using the OG data, since Dropbox handles some normalization for us. However,
the meta data tags aren't updated on client side navigations.

As a side-effect I dropped the description.

#### What are the relevant tickets?

https://github.com/range-labs/range-for-chrome/issues/7

#### Screenshots (if appropriate)

N/A

#### What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/jn7sNNFTpsxdfVkAMW/giphy-downsized.gif)

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered