### PR TITLE
Stop reporting suggestions for 1 minute after an error

### DIFF
--- a/ext/background/api.js
+++ b/ext/background/api.js
@@ -79,6 +79,7 @@ function request(path, params = {}) {
       return resp.json();
     })
     .catch(e => {
+      _sessionCache = {};
       throw new Error(`Network error, status: ${statusCode},  ${statusText} (${String(e)})`);
     })
     .then(resp => {

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Range for Chrome",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Capture work from your browser based tools and share progress with your team.",
   "permissions": ["storage", "cookies", "https://api.range.co/*"],
   "browser_action": {

--- a/ext/sites/_base.js
+++ b/ext/sites/_base.js
@@ -135,7 +135,7 @@ class Monitor {
   resetOnNav() {
     window.addEventListener('popstate', () => {
       this._log('popstate fired');
-      this._reset;
+      this._reset();
     });
     this._resetOnNav = true;
     return this;


### PR DESCRIPTION
#### What's this PR do?

Fails new suggestion requests if an error occurred within the last minute.

#### Where should the reviewer start?

Diff

#### Any background context you want to provide?

This is a relatively blunt instrument to avoid bad clients hammering us.

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/WwfHKIyg0P7ENQEayl/200w_d.gif)

#### Definition of Done:

- [x] Code is easy to understand and conforms with Prettier & eslint configs
- [x] Incomplete code is marked with TODOs
- [x] Code is suitably instrumented with logging and metrics
- [x] Documentation has been updated as appropriate
- [x] Manifest has been updated and version incremented correctly
- [x] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered