### PR TITLE
Fix Dropbox Paper integration with switch to iframe

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -32,7 +32,8 @@
     },
     {
       "matches": ["https://paper.dropbox.com/*"],
-      "js": ["sites/_base.js", "sites/dropbox.js"]
+      "js": ["sites/_base.js", "sites/dropbox.js"],
+      "all_frames": true
     },
     {
       "matches": ["https://*.quip.com/*"],

--- a/ext/sites/dropbox.js
+++ b/ext/sites/dropbox.js
@@ -9,21 +9,17 @@ new Monitor()
   .reason(Reasons.EDITED)
   .past()
 
-  // Paper encodes the documents canonical ID in the Open Graph URL in the form:
-  //   https://paper.dropbox.com/doc/Some-Title--[base64id]
-  // or sometimes:
-  //   https://paper.dropbox.com/doc/[base64id]
+  // Paper runs in an iframe and encodes the document's canonical ID in the URL with the form:
+  //   https://paper.dropbox.com/doc/Title-Of-Document-[base64id]
   .sourceID(() => {
-    let p = document.location.pathname;
-    let i = p.indexOf('--');
-    if (i !== -1) return p.substr(i + 2);
-    else return p.split('/').pop();
+    let parts = document.location.pathname.split('-');
+    return parts[parts.length - 1];
   })
 
   .setProvider('dropbox_paper', 'Dropbox Paper')
   .setType(Types.DOCUMENT)
   .attachment({
     name: () => textContent('.hp-header-title', 'Untitled'),
-    html_url: () => document.location.href,
+    html_url: () => document.querySelector('.hp-sharing-header-copylink').href,
     description: () => '',
   });


### PR DESCRIPTION
#### What's this PR do?

Updates the Dropbox Paper support in the extension to work with the new changes to Dropbox Paper.

The Paper editor now runs in an iframe at www.dropbox.com, but the URL of the iframe is still at paper.dropbox.com. After some experimentation, I found the following changes were necessary:

- Add the `all_frames` option to the manifest to make sure that our content script runs in the paper.dropbox.com iframe
- Change the way that we get the canonical ID, since the URL structure of the iframe has changed
- Change the way that we get the URL to the document, since we want the www.dropbox.com URL that is publicly accessible (the iframe URL returns "Forbidden" when accessed directly)

@kowitz mentioned that he had another change to the Chrome manifest, so we should hold this and release them both in the same new extension version to avoid two manifest changes.

#### Where should the reviewer start?

Small diff

#### What gif best describes this PR or how it makes you feel?

![changes](https://media.tenor.com/images/4b446706b20bb14f1aef6e3fa5954e9a/tenor.gif)

#### Definition of Done:

- [ ] Code is easy to understand and conforms with Prettier & eslint configs
- [ ] Incomplete code is marked with TODOs
- [ ] Code is suitably instrumented with logging and metrics
- [ ] Documentation has been updated as appropriate
- [ ] Manifest has been updated and version incremented correctly
- [ ] [OWASP Top 10](https://www.owasp.org/index.php/Top_10-2017_Top_10) have been considered
